### PR TITLE
Add support for role-arn option

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,8 @@ jobs:
 * `PARAMETER_OVERRIDES` - [Optional]. Parameters to input in the template.
   * Type: `string | list[string]`
   * Syntax: `AliasName=prod` `AliasName=prod ApiUrl=https://api.com/api/v1`
+* `ROLE_ARN` - [Optional]. ARN of AWS IAM role that AWS CloudFormation assumes when executing the change set.
+  * Type: `string`
 
 ### Examples
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -60,6 +60,10 @@ if [[ ! -z "$PARAMETER_OVERRIDES" ]]; then
     PARAMETER_OVERRIDES="--parameter-overrides $PARAMETER_OVERRIDES"
 fi
 
+if [[ ! -z "$ROLE_ARN" ]]; then
+    ROLE_ARN="--role-arn ${ROLE_ARN}"
+fi
+
 mkdir ~/.aws
 touch ~/.aws/credentials
 touch ~/.aws/config
@@ -74,4 +78,4 @@ output = text
 region = $AWS_REGION" > ~/.aws/config
 
 aws cloudformation package --template-file $TEMPLATE --output-template-file serverless-output.yaml --s3-bucket $AWS_DEPLOY_BUCKET $AWS_BUCKET_PREFIX $FORCE_UPLOAD $USE_JSON
-aws cloudformation deploy --template-file serverless-output.yaml --stack-name $AWS_STACK_NAME $CAPABILITIES $PARAMETER_OVERRIDES
+aws cloudformation deploy --template-file serverless-output.yaml --stack-name $AWS_STACK_NAME $CAPABILITIES $PARAMETER_OVERRIDES $ROLE_ARN


### PR DESCRIPTION
This PR introduces support of the `role-arn` option, which allows you to provide a role for CloudFormation to assume to execute the change set.

[cli reference](https://docs.aws.amazon.com/cli/latest/reference/cloudformation/deploy/index.html#options)